### PR TITLE
Fix quotes nesting

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,7 +1,7 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
+        "lineComment": "#",
         // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
         "blockComment": [ "/*", "*/" ]
     },

--- a/syntaxes/peg.tmLanguage.json
+++ b/syntaxes/peg.tmLanguage.json
@@ -23,13 +23,39 @@
 			}]
 		},
 		"strings": {
-			"name": "string.quoted.double.peg",
-			"begin": "(\"|')",
-			"end": "(\"|')",
 			"patterns": [
 				{
-					"name": "constant.character.escape.peg",
-					"match": "\\\\."
+					"name": "string.regexp.peg",
+					"begin": "\\[",
+					"end": "]",
+					"patterns": [
+						{
+							"name": "constant.character.escape.peg",
+							"match": "\\\\."
+						}
+					]
+				},
+				{
+					"name": "string.quoted.double.peg",
+					"begin": "\"",
+					"end": "\"",
+					"patterns": [
+						{
+							"name": "constant.character.escape.peg",
+							"match": "\\\\."
+						}
+					]
+				},
+				{
+					"name": "string.quoted.single.peg",
+					"begin": "'",
+					"end": "'",
+					"patterns": [
+						{
+							"name": "constant.character.escape.peg",
+							"match": "\\\\."
+						}
+					]
 				}
 			]
 		},


### PR DESCRIPTION
Hi Austin,

Thanks for the extension, it is useful. However, I found that existing grammar does not seem to play well with nesting of quotes, e.g. strings like

- "'"
- '"'
- ["']

would break highlighting.

This PR is an attempt to fix that.